### PR TITLE
Update useRegisterRef to use internal refs instead of state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,9 @@
       },
       "devDependencies": {
         "@mediamonks/eslint-config": "^2.0.6",
+        "@mediamonks/eslint-config-react": "^2.1.11",
         "@mediamonks/eslint-config-typescript": "^1.0.8",
+        "@mediamonks/eslint-config-typescript-react": "^1.0.10",
         "@mediamonks/prettier-config": "^1.0.1",
         "@storybook/addon-docs": "^7.0.0-alpha.56",
         "@storybook/builder-vite": "^7.0.0-alpha.56",
@@ -1859,6 +1861,20 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/runtime-corejs3": {
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.20.6.tgz",
+      "integrity": "sha512-tqeujPiuEfcH067mx+7otTQWROVMKHXEaOQcAeNV5dDdbPWvPcFA8/W9LXw2NfjNmOetqLl03dfnG2WALPlsRQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "core-js-pure": "^3.25.1",
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.18.10",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
@@ -2855,6 +2871,17 @@
         "eslint-plugin-unicorn": "^45.0.0"
       }
     },
+    "node_modules/@mediamonks/eslint-config-react": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@mediamonks/eslint-config-react/-/eslint-config-react-2.1.11.tgz",
+      "integrity": "sha512-EOJQumTRClXgN23xo9rW6gChVW6Y7zaoZ6Uat2HO8xAZypBc6+NwgUN8r9/4ZucAbOX+t7JNvqISjM6q870QKw==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint-plugin-jsx-a11y": "^6.6.1",
+        "eslint-plugin-react": "^7.31.11",
+        "eslint-plugin-react-hooks": "^4.6.0"
+      }
+    },
     "node_modules/@mediamonks/eslint-config-typescript": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@mediamonks/eslint-config-typescript/-/eslint-config-typescript-1.0.8.tgz",
@@ -2865,6 +2892,12 @@
         "@typescript-eslint/parser": "^5.44.0",
         "typescript": "^4.9.3"
       }
+    },
+    "node_modules/@mediamonks/eslint-config-typescript-react": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@mediamonks/eslint-config-typescript-react/-/eslint-config-typescript-react-1.0.10.tgz",
+      "integrity": "sha512-DMHzZbenLGanY87xPy1SbpxHVIZ8U1T0uAkG+ftt9cp7aJIlOFyb9gdY/Wi3phZboU6rrq0TnPi4Do0AfvXtuw==",
+      "dev": true
     },
     "node_modules/@mediamonks/prettier-config": {
       "version": "1.0.1",
@@ -5525,6 +5558,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+      "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
+      "integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
+      }
+    },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -5545,6 +5611,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/ast-types/node_modules/tslib": {
       "version": "2.4.1",
@@ -5602,6 +5675,23 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/axe-core": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
+      "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
+      "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
@@ -7180,6 +7270,18 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-js-pure": {
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.26.1.tgz",
+      "integrity": "sha512-VVXcDpp/xJ21KdULRq/lXdLzQAtX7+37LzpyfFM973il0tWSsDEoyzG38G14AjTpK9VTfiNM9jnFauq/CpaWGQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -7256,6 +7358,13 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
       "dev": true
+    },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/data-urls": {
       "version": "3.0.2",
@@ -8559,6 +8668,139 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.1.tgz",
+      "integrity": "sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.9",
+        "aria-query": "^4.2.2",
+        "array-includes": "^3.1.5",
+        "ast-types-flow": "^0.0.7",
+        "axe-core": "^4.4.3",
+        "axobject-query": "^2.2.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^3.3.2",
+        "language-tags": "^1.0.5",
+        "minimatch": "^3.1.2",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.31.11",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.11.tgz",
+      "integrity": "sha512-TTvq5JsT5v56wPa9OYHzsrOlHzKZKjV+aLgS+55NJP/cuzdiQPC7PfYoUjMoxlffKtvijpk7vA/jmuqRb9nohw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flatmap": "^1.3.1",
+        "array.prototype.tosorted": "^1.1.1",
+        "doctrine": "^2.1.0",
+        "estraverse": "^5.3.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.6",
+        "object.fromentries": "^2.0.6",
+        "object.hasown": "^1.1.2",
+        "object.values": "^1.1.6",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.3",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+      "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/eslint-plugin-unicorn": {
       "version": "45.0.1",
@@ -13836,6 +14078,20 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
+      "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "array-includes": "^3.1.5",
+        "object.assign": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
@@ -13861,6 +14117,23 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
+      "integrity": "sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.6.tgz",
+      "integrity": "sha512-HNkaCgM8wZgE/BZACeotAAgpL9FUjEnhgF0FVQMIgH//zqTPreLYMb3rWYkYAqPoF75Jwuycp1da7uz66cfFQg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
       }
     },
     "node_modules/latest-version": {
@@ -15049,6 +15322,53 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.6.tgz",
+      "integrity": "sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
+      "integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.hasown": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
+      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.map": {
@@ -17740,6 +18060,26 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
+      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.padend": {
@@ -20978,6 +21318,17 @@
         "regenerator-runtime": "^0.13.11"
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.20.6.tgz",
+      "integrity": "sha512-tqeujPiuEfcH067mx+7otTQWROVMKHXEaOQcAeNV5dDdbPWvPcFA8/W9LXw2NfjNmOetqLl03dfnG2WALPlsRQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "core-js-pure": "^3.25.1",
+        "regenerator-runtime": "^0.13.11"
+      }
+    },
     "@babel/template": {
       "version": "7.18.10",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
@@ -21720,12 +22071,25 @@
       "dev": true,
       "requires": {}
     },
+    "@mediamonks/eslint-config-react": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@mediamonks/eslint-config-react/-/eslint-config-react-2.1.11.tgz",
+      "integrity": "sha512-EOJQumTRClXgN23xo9rW6gChVW6Y7zaoZ6Uat2HO8xAZypBc6+NwgUN8r9/4ZucAbOX+t7JNvqISjM6q870QKw==",
+      "dev": true,
+      "requires": {}
+    },
     "@mediamonks/eslint-config-typescript": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@mediamonks/eslint-config-typescript/-/eslint-config-typescript-1.0.8.tgz",
       "integrity": "sha512-S9e/CK8UxQqF/uSFiOxMwdUFC1/m2/jqPfLh0ZavV1EtAC9yqdpjp30y0v4aMkqVCuNApw4MCJ9b23iqYnIPIA==",
       "dev": true,
       "requires": {}
+    },
+    "@mediamonks/eslint-config-typescript-react": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@mediamonks/eslint-config-typescript-react/-/eslint-config-typescript-react-1.0.10.tgz",
+      "integrity": "sha512-DMHzZbenLGanY87xPy1SbpxHVIZ8U1T0uAkG+ftt9cp7aJIlOFyb9gdY/Wi3phZboU6rrq0TnPi4Do0AfvXtuw==",
+      "dev": true
     },
     "@mediamonks/prettier-config": {
       "version": "1.0.1",
@@ -23742,6 +24106,33 @@
         "es-shim-unscopables": "^1.0.0"
       }
     },
+    "array.prototype.flatmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+      "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0"
+      }
+    },
+    "array.prototype.tosorted": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
+      "integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
+      }
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -23764,6 +24155,13 @@
           "dev": true
         }
       }
+    },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
+      "dev": true,
+      "peer": true
     },
     "async": {
       "version": "3.2.4",
@@ -23800,6 +24198,20 @@
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
+    },
+    "axe-core": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
+      "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA==",
+      "dev": true,
+      "peer": true
+    },
+    "axobject-query": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
+      "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
+      "dev": true,
+      "peer": true
     },
     "babel-core": {
       "version": "7.0.0-bridge.0",
@@ -25027,6 +25439,13 @@
         "browserslist": "^4.21.4"
       }
     },
+    "core-js-pure": {
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.26.1.tgz",
+      "integrity": "sha512-VVXcDpp/xJ21KdULRq/lXdLzQAtX7+37LzpyfFM973il0tWSsDEoyzG38G14AjTpK9VTfiNM9jnFauq/CpaWGQ==",
+      "dev": true,
+      "peer": true
+    },
     "core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -25089,6 +25508,13 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
       "dev": true
+    },
+    "damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "peer": true
     },
     "data-urls": {
       "version": "3.0.2",
@@ -26122,6 +26548,111 @@
           "peer": true
         }
       }
+    },
+    "eslint-plugin-jsx-a11y": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.1.tgz",
+      "integrity": "sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@babel/runtime": "^7.18.9",
+        "aria-query": "^4.2.2",
+        "array-includes": "^3.1.5",
+        "ast-types-flow": "^0.0.7",
+        "axe-core": "^4.4.3",
+        "axobject-query": "^2.2.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^3.3.2",
+        "language-tags": "^1.0.5",
+        "minimatch": "^3.1.2",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "aria-query": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+          "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.10.2",
+            "@babel/runtime-corejs3": "^7.10.2"
+          }
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "7.31.11",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.11.tgz",
+      "integrity": "sha512-TTvq5JsT5v56wPa9OYHzsrOlHzKZKjV+aLgS+55NJP/cuzdiQPC7PfYoUjMoxlffKtvijpk7vA/jmuqRb9nohw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flatmap": "^1.3.1",
+        "array.prototype.tosorted": "^1.1.1",
+        "doctrine": "^2.1.0",
+        "estraverse": "^5.3.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.6",
+        "object.fromentries": "^2.0.6",
+        "object.hasown": "^1.1.2",
+        "object.values": "^1.1.6",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.3",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.8"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true,
+          "peer": true
+        },
+        "resolve": {
+          "version": "2.0.0-next.4",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
+          "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "is-core-module": "^2.9.0",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true,
+      "peer": true,
+      "requires": {}
     },
     "eslint-plugin-unicorn": {
       "version": "45.0.1",
@@ -29929,6 +30460,17 @@
         }
       }
     },
+    "jsx-ast-utils": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
+      "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "array-includes": "^3.1.5",
+        "object.assign": "^4.1.3"
+      }
+    },
     "keyv": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
@@ -29949,6 +30491,23 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
+    },
+    "language-subtag-registry": {
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
+      "integrity": "sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==",
+      "dev": true,
+      "peer": true
+    },
+    "language-tags": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.6.tgz",
+      "integrity": "sha512-HNkaCgM8wZgE/BZACeotAAgpL9FUjEnhgF0FVQMIgH//zqTPreLYMb3rWYkYAqPoF75Jwuycp1da7uz66cfFQg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "language-subtag-registry": "^0.3.20"
+      }
     },
     "latest-version": {
       "version": "7.0.0",
@@ -30866,6 +31425,41 @@
         "array-slice": "^1.0.0",
         "for-own": "^1.0.0",
         "isobject": "^3.0.0"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.6.tgz",
+      "integrity": "sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.6.tgz",
+      "integrity": "sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
+    "object.hasown": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
+      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       }
     },
     "object.map": {
@@ -32932,6 +33526,23 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
+      }
+    },
+    "string.prototype.matchall": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
+      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4"
       }
     },
     "string.prototype.padend": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
   "eslintConfig": {
     "extends": [
       "@mediamonks/eslint-config",
-      "@mediamonks/eslint-config-typescript"
+      "@mediamonks/eslint-config-react",
+      "@mediamonks/eslint-config-typescript",
+      "@mediamonks/eslint-config-typescript-react"
     ],
     "parserOptions": {
       "project": "./tsconfig.json"
@@ -60,12 +62,15 @@
             "prop": false
           }
         }
-      ]
+      ],
+      "react/jsx-no-literals": "off"
     }
   },
   "devDependencies": {
     "@mediamonks/eslint-config": "^2.0.6",
+    "@mediamonks/eslint-config-react": "^2.1.11",
     "@mediamonks/eslint-config-typescript": "^1.0.8",
+    "@mediamonks/eslint-config-typescript-react": "^1.0.10",
     "@mediamonks/prettier-config": "^1.0.1",
     "@storybook/addon-docs": "^7.0.0-alpha.56",
     "@storybook/builder-vite": "^7.0.0-alpha.56",

--- a/src/useRegisterRef/useRegisterRef.stories.mdx
+++ b/src/useRegisterRef/useRegisterRef.stories.mdx
@@ -6,7 +6,7 @@ import { Meta } from '@storybook/addon-docs';
 
 # useRegisterRef
 
-A helper hook that allows you to easily register and access refs by "name", including ref collections. 
+A helper hook that allows you to easily register and access refs by "name", even supports arrays.
 
 Due to the dynamic nature of collecting refs, it's tricky to know how many `useRef` calls you need
 to consistently do without explicitly setting (and updating when your refs change) the amount.
@@ -15,6 +15,19 @@ This is why this hook doesn't use `useRef` at all, but stores the actual DOM ele
 This means that other hooks that rely on `ref.current` will not work. In that case you should
 change the hook (if you can), or wrap your element inside a ref (TODO: this can be easily done
 with the `todo` hook).
+
+This hooks returns a `ref` object that will never change reference. Instead, the object will be
+mutated to store the HTML elements. This will allow similar usages to `useRef`. `refs.item` for
+example is similar to `ref.current` If you pass the `refs` object to other functions, it won't
+need to be added to dependency arrays, but as soon as that code is executed, the updated value
+will be available there.
+
+> **Note** due to the general usage of refs on HTML elements, you will almost always have them
+  available as soon as you execute code in a `useEffect`, and you wont use them anymore in an
+  `unmout`. For this reason, the hook doesn't enforce the `| null` type on ref object keys, so
+  you don't have to check for its existence in your code everytime you use it. If you do use
+  optional refs, or in situations where they might not exist, you must explicitly type them as
+  `| null` or as optional (`?`) in your `Refs` type.
 
 ## Reference
 
@@ -42,8 +55,10 @@ function useRegisterRef<T extends Record<string, unknown>>(): readonly [
 ```tsx
 const [refs, registerRef] = useRegisterRef<Refs>();
 ````
-
 ```tsx
+import { useEffect } from 'react';
+import { useRegisterRef } from '@mediamonks/react-hooks';
+
 type Refs = {
   element: HTMLDivElement;
   elements: ReadonlyArray<HTMLSpanElement>;
@@ -52,12 +67,14 @@ type Refs = {
 function DemoComponent() {
   const [refs, registerRef] = useRegisterRef<Refs>();
 
-  console.log(refs.element) // HTMLDivElement
-  console.log(refs.elements); // Array<HTMLSpanElement>
+  useEffect(() => {
+    console.log(refs.element) // HTMLDivElement
+    console.log(refs.elements); // Array<HTMLSpanElement>
+  }, []);
 
   return (
     <div ref={registerRef('element')}>
-      {items.map((item, index) => (
+      {['AA', 'BB'].map((item, index) => (
         <span key={item} ref={registerRef('elements[]', index)}>{item}</span>
       ))}
     </div>

--- a/src/useRegisterRef/useRegisterRef.stories.tsx
+++ b/src/useRegisterRef/useRegisterRef.stories.tsx
@@ -1,22 +1,92 @@
+/* eslint-disable react/jsx-no-bind,react/no-multi-comp */
 import type { StoryObj } from '@storybook/react';
-import { useState } from 'react';
-import { useRegisterRef } from './useRegisterRef';
 import { shuffle } from 'lodash-es';
+import { type ReactElement, useEffect, useState } from 'react';
+import { useRegisterRef } from './useRegisterRef';
 
 export default {
   title: 'useRegisterRef',
 };
 
-type DemoComponentProps = {};
-
 type Refs = {
-  item1: HTMLElement;
-  item2: HTMLElement;
-  btnMore: HTMLButtonElement;
-  listItems: ReadonlyArray<HTMLElement>;
-  keyList: ReadonlyArray<HTMLElement>;
+  item1: HTMLElement | null;
+  item2: HTMLElement | null;
+  btnMore: HTMLButtonElement | null;
+  listItems?: ReadonlyArray<HTMLElement>;
+  keyList?: ReadonlyArray<HTMLElement>;
 };
-function DemoComponent({}: DemoComponentProps) {
+
+type RefTableProps = {
+  refs: Refs;
+};
+
+function useRerender(interval = 100): void {
+  // eslint-disable-next-line react/hook-use-state
+  const [, setRenderState] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setRenderState((oldValue) => oldValue + 1);
+    }, interval);
+    return (): void => {
+      clearInterval(id);
+    };
+  }, [interval]);
+}
+
+function RefTable({ refs }: RefTableProps): ReactElement {
+  // force re-render to show the new value of these refs
+  useRerender();
+
+  return (
+    <table className="table">
+      <thead>
+        <tr>
+          <th scope="col">Ref name</th>
+          <th scope="col">Resolved Element</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>item1</td>
+          <td>
+            <code>{refs.item1?.outerHTML ?? null}</code>
+          </td>
+        </tr>
+        <tr>
+          <th>item2</th>
+          <td>
+            <code>{refs.item2?.outerHTML ?? null}</code>
+          </td>
+        </tr>
+        <tr>
+          <td>btnMore</td>
+          <td>
+            <code>{refs.btnMore?.outerHTML ?? null}</code>
+          </td>
+        </tr>
+        <tr>
+          <td>itemList</td>
+          <td>
+            <code>
+              <pre>{refs.listItems?.map((element) => element.outerHTML).join('\n')}</pre>
+            </code>
+          </td>
+        </tr>
+        <tr>
+          <td>keyList</td>
+          <td>
+            <code>
+              <pre>{refs.keyList?.map((element) => element.outerHTML).join('\n')}</pre>
+            </code>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}
+
+function DemoComponent(): ReactElement {
   const [refs, registerRef] = useRegisterRef<Refs>();
   const [count, setCount] = useState(3);
   const [keyList, setKeyList] = useState(['key A', 'key B', 'key C']);
@@ -32,52 +102,9 @@ function DemoComponent({}: DemoComponentProps) {
           in the array.
         </p>
       </div>
-      <div>
-        <table className="table">
-          <thead>
-            <tr>
-              <th scope="col">Ref name</th>
-              <th scope="col">Resolved Element</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td scope="row">item1</td>
-              <td>
-                <code>{refs.item1?.outerHTML ?? null}</code>
-              </td>
-            </tr>
-            <tr>
-              <td>item2</td>
-              <td>
-                <code>{refs.item2?.outerHTML ?? null}</code>
-              </td>
-            </tr>
-            <tr>
-              <td>btnMore</td>
-              <td>
-                <code>{refs.btnMore?.outerHTML ?? null}</code>
-              </td>
-            </tr>
-            <tr>
-              <td>itemList</td>
-              <td>
-                <code>
-                  <pre>{refs.listItems?.map((element) => element.outerHTML).join('\n')}</pre>
-                </code>
-              </td>
-            </tr>
-            <tr>
-              <td>keyList</td>
-              <td>
-                <code>
-                  <pre>{refs.keyList?.map((element) => element.outerHTML).join('\n')}</pre>
-                </code>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+
+      <RefTable refs={refs} />
+
       <div className="card border-dark" data-ref="test-area">
         <div className="card-header">Test Area</div>
         <div className="card-body">
@@ -86,14 +113,18 @@ function DemoComponent({}: DemoComponentProps) {
           <button
             type="button"
             className="btn btn-danger btn-sm"
-            onClick={() => setCount((oldCount) => Math.max(0, oldCount - 1))}
+            onClick={(): void => {
+              setCount((oldCount) => Math.max(0, oldCount - 1));
+            }}
           >
             Less
           </button>{' '}
           <button
             type="button"
             className="btn btn-success btn-sm"
-            onClick={() => setCount((oldCount) => Math.min(10, oldCount + 1))}
+            onClick={(): void => {
+              setCount((oldCount) => Math.min(10, oldCount + 1));
+            }}
             ref={registerRef('btnMore')}
           >
             More
@@ -108,7 +139,9 @@ function DemoComponent({}: DemoComponentProps) {
           <button
             type="button"
             className="btn btn-primary btn-sm"
-            onClick={() => setKeyList(shuffle(keyList))}
+            onClick={(): void => {
+              setKeyList(shuffle(keyList));
+            }}
           >
             Shuffle
           </button>
@@ -124,9 +157,9 @@ function DemoComponent({}: DemoComponentProps) {
     </div>
   );
 }
-export const Demo: StoryObj<DemoComponentProps> = {
-  render(args) {
-    return <DemoComponent {...args} />;
+export const demo: StoryObj = {
+  render() {
+    return <DemoComponent />;
   },
   name: 'demo',
   args: {

--- a/src/useRegisterRef/useRegisterRef.test.tsx
+++ b/src/useRegisterRef/useRegisterRef.test.tsx
@@ -30,12 +30,50 @@ describe('useRegisterRef', () => {
     const [refs, registerRef] = result.current;
 
     await act(() => {
-      // @ts-ignore
+      // @ts-expect-error generic inference doesn't work properly in tests
       registerRef('items[]', 0)('A');
-      // @ts-ignore
+      // @ts-expect-error generic inference doesn't work properly in tests
       registerRef('items[]', 1)('B');
     });
 
     expect(refs).toEqual({ items: ['A', 'B'] });
+  });
+
+  it('should be able to set a ref to null', async () => {
+    const { result } = renderHook(useRegisterRef);
+    const [refs, registerRef] = result.current;
+
+    await act(() => {
+      registerRef('item')('A');
+    });
+
+    expect(refs).toEqual({ item: 'A' });
+
+    await act(() => {
+      registerRef('item')(null);
+    });
+
+    expect(refs).toEqual({ item: null });
+  });
+
+  it('should trim Array refs when items disappear', async () => {
+    const { result } = renderHook(useRegisterRef);
+    const [refs, registerRef] = result.current;
+
+    await act(() => {
+      // @ts-expect-error generic inference doesn't work properly in tests
+      registerRef('items[]', 0)('A');
+      // @ts-expect-error generic inference doesn't work properly in tests
+      registerRef('items[]', 1)('B');
+    });
+
+    expect(refs).toEqual({ items: ['A', 'B'] });
+
+    await act(() => {
+      // @ts-expect-error generic inference doesn't work properly in tests
+      registerRef('items[]', 1)(null);
+    });
+
+    expect(refs).toEqual({ items: ['A'] });
   });
 });

--- a/src/useRegisterRef/useRegisterRef.ts
+++ b/src/useRegisterRef/useRegisterRef.ts
@@ -1,16 +1,16 @@
-import { useCallback, useState } from 'react';
 import { memoize } from 'lodash-es';
+import { useCallback, useRef } from 'react';
 
 // appends the `[]` after the existing key when the type is an Array
-export type RefKey<T, K extends string> = T extends ReadonlyArray<any> ? `${K}[]` : K;
+export type RefKey<T, K extends string> = T extends ReadonlyArray<unknown> ? `${K}[]` : K;
 // only returns non-array keys
-export type RefKeyPlain<T, K extends string> = T extends ReadonlyArray<any> ? never : K;
+export type RefKeyPlain<T, K extends string> = T extends ReadonlyArray<unknown> ? never : K;
 // only returns array keys
-export type RefKeyList<T, K extends string> = T extends ReadonlyArray<any> ? `${K}[]` : never;
+export type RefKeyList<T, K extends string> = T extends ReadonlyArray<unknown> ? `${K}[]` : never;
 
 // get modified and optionally filtered object keys
 export type RefKeys<
-  T extends Record<string, any>,
+  T extends Record<string, unknown>,
   M extends 'all' | 'list' | 'plain' = 'all',
 > = Exclude<
   keyof {
@@ -23,8 +23,8 @@ export type RefKeys<
   number | symbol
 >;
 
-function arrayTrimEnd<T extends Array<unknown>>(array: T) {
-  const existingElementIndex = [...array].reverse().findIndex((val) => Boolean(val));
+function arrayTrimEnd<T extends Array<unknown>>(array: T): void {
+  const existingElementIndex = [...array].reverse().findIndex(Boolean);
   const lastExistingItemIndex =
     existingElementIndex === -1 ? 0 : array.length - existingElementIndex;
   array.splice(lastExistingItemIndex);
@@ -48,62 +48,78 @@ function arrayTrimEnd<T extends Array<unknown>>(array: T) {
  *  doSomethingWithRefs(refs); // the complete object of all registered refs as HTML Elements
  *
  *  // or individual refs
- *  console.log(refs.elements); // the 3 <li> elements collected in the array
+ *  useEffect(() => {
+ *    console.log(refs.elements); // the 3 <li> elements collected in the array
+ *  }, [refs.elements]);
+ *
  *
  *  // use `registerRef(...)` in your JSX to collect the ref
  *  <div ref={registerRef('element')}>
  *    {Array.from({ length: 3 }).map((_, index) => (
- *      // array-type refs are required to append `[]` when registering
- *      <li key={index} ref={registerRef('elements[]')}>{index}</li>
+ *      // array-type refs are required to append `[]` to the key and provide an index when registering
+ *      <li key={index} ref={registerRef('elements[]', index)}>{index}</li>
  *    ))}
  *  </div>
  * ```
  */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types,@typescript-eslint/explicit-function-return-type
 export function useRegisterRef<T extends Record<string, unknown>>() {
-  const [refs, setRefs] = useState({} as T);
+  // const [refs, setRefs] = useState({} as T);
+  const refs = useRef({} as T);
 
   // use method overloading to make the 2nd `index` parameter only there and required for array-like
   // refs, and leave it out for plain single element refs;
   function registerRefInternal<N extends RefKeys<T, 'plain'>>(
     name: N,
-  ): (ref: Exclude<T[N], undefined>) => void;
+  ): (ref: Exclude<T[N], undefined> | null) => void;
   function registerRefInternal<N extends RefKeys<T, 'list'>>(
     name: N,
     index: number,
-  ): (ref: Exclude<T[N], undefined>) => void;
+  ): (ref: Exclude<T[N], undefined> | null) => void;
   function registerRefInternal<N extends RefKeys<T>>(
     name: N,
     index?: number,
-  ): (ref: Exclude<T[N], undefined>) => void {
-    return (ref: Exclude<T[N], undefined>) => {
-      setRefs((oldRefs) => {
-        // array mode
-        if (name.endsWith('[]')) {
-          const cleanName = name.replace('[]', '') as N;
-          if (!oldRefs[cleanName]) oldRefs[cleanName] = [] as T[N];
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const slot = oldRefs[cleanName] as Array<unknown>;
-          slot[index!] = ref;
+  ): (ref: Exclude<T[N], undefined> | null) => void {
+    return (ref: Exclude<T[N], undefined> | null) => {
+      // array mode
+      if (name.endsWith('[]')) {
+        const cleanName = name.replace('[]', '') as N;
 
-          // if we set something to `null`, try to clean up the array
-          if (!ref) {
-            arrayTrimEnd(slot);
-          }
+        if (!refs.current[cleanName]) {
+          refs.current[cleanName] = [] as T[N];
         }
-        // plain mode
-        else {
-          oldRefs[name] = ref;
+
+        // clone array so we can track changes
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const slot = [...(refs.current[cleanName] as ReadonlyArray<unknown>)];
+
+        if (index === undefined) {
+          throw new Error(
+            `Missing "index" parameter for ref "${name}", Array refs should always provide an index`,
+          );
         }
-        // force re-render
-        return { ...oldRefs };
-      });
+        slot[index] = ref;
+
+        // if we set something to `null`, try to clean up the array
+        if (!ref) {
+          arrayTrimEnd(slot);
+        }
+
+        refs.current[cleanName] = slot as T[N];
+      }
+      // plain mode
+      else {
+        // we can set refs to null, even though the type doesn't reflect this
+        refs.current[name] = ref as Exclude<typeof ref, null>;
+      }
     };
   }
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const registerRef = useCallback(
     // memoize the function creation so it doesn't cause re-renders when they are passed to the `ref` attribute
-    memoize(registerRefInternal, (...args) => `${args[0]}-${args[1]}`),
+    memoize(registerRefInternal, (name: string, index?: number) => `${name}-${index ?? ''}`),
     [],
   );
-  return [refs, registerRef] as const;
+  return [refs.current, registerRef] as const;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,7 @@
   },
   "include": [
     "./src/**/*.ts",
+    "./src/**/*.tsx",
+    "./src/**/*.stories.tsx",
   ]
 }


### PR DESCRIPTION
This makes its usage similar to normal useRefs, and since it doesn't use a state anymore, it won't trigger re-renders when refs are registered.

Also updated eslint, added tests, and improved the code + docs a bit.