### PR TITLE
Create ensureForwardRef helper

### DIFF
--- a/src/ensuredForwardRef/ensuredForwardRef.stories.mdx
+++ b/src/ensuredForwardRef/ensuredForwardRef.stories.mdx
@@ -1,0 +1,39 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="ensuredForwardRef" />
+
+# ensuredForwardRef
+
+Helper function to create ForwardRef component in which component function _always_ receive a
+RefObject. New component function has the same function fignature as ForwardRef.
+
+## Reference
+
+```ts
+export function ensuredForwardRef<T, P = Record<string | number | symbol, unknown>>(
+  Component: EnsuredForwardRefRenderFunction<T, P>,
+): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
+```
+
+### Returns
+
+`ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>`
+
+## Usage
+
+```tsx
+const DemoComponent = ensuredForwardRef<HTMLDivElement>((_, ref) => {
+  console.log(ref); // MutableRefObject<HTMLDivElement | null>
+
+  return <div ref={ref} />;
+});
+
+...
+
+const myRef = useRef<HTMLDivElement>();
+const [myRef, setMyRef] = useState<HTMLDivElement | null>(null);
+
+<DemoComponent />
+<DemoComponent ref={myRef} />
+<DemoComponent ref={setMyRef} />
+```

--- a/src/ensuredForwardRef/ensuredForwardRef.test.tsx
+++ b/src/ensuredForwardRef/ensuredForwardRef.test.tsx
@@ -1,0 +1,54 @@
+import { render } from '@testing-library/react';
+import type { MutableRefObject } from 'react';
+import { ensuredForwardRef } from './ensuredForwardRef';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const TestComponent = ensuredForwardRef<HTMLDivElement>((_, ref) => {
+  if (!('current' in ref)) {
+    throw new Error('ref is not a RefObject');
+  }
+
+  return <div ref={ref} data-testid="test" />;
+});
+
+describe('ensuredForwardRef', () => {
+  it('should not crash', () => {
+    render(<TestComponent />);
+  });
+
+  it('should store ref in refObject', () => {
+    const ref: MutableRefObject<HTMLDivElement | null> = {
+      current: null,
+    };
+
+    const { getByTestId } = render(<TestComponent ref={ref} />);
+    expect(getByTestId('test')).toEqual(ref.current);
+  });
+
+  it('should accept ref functions', () => {
+    let ref1: HTMLDivElement | null = null;
+
+    const ref1Function = jest.fn((_ref: HTMLDivElement | null) => {
+      ref1 = _ref;
+    });
+
+    // First render
+    const { getByTestId, rerender, unmount } = render(<TestComponent ref={ref1Function} />);
+    expect(ref1).toEqual(getByTestId('test'));
+
+    let ref2: HTMLDivElement | null = null;
+
+    const ref2Function = jest.fn((_ref: HTMLDivElement | null) => {
+      ref2 = _ref;
+    });
+
+    // New instance with key update
+    rerender(<TestComponent ref={ref2Function} key="rerender" />);
+    expect(ref1).toEqual(null);
+    expect(ref2).toEqual(getByTestId('test'));
+
+    // Sets ref to null
+    unmount();
+    expect(ref2).toEqual(null);
+  });
+});

--- a/src/ensuredForwardRef/ensuredForwardRef.test.tsx
+++ b/src/ensuredForwardRef/ensuredForwardRef.test.tsx
@@ -2,7 +2,6 @@ import { render } from '@testing-library/react';
 import type { MutableRefObject } from 'react';
 import { ensuredForwardRef } from './ensuredForwardRef';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const TestComponent = ensuredForwardRef<HTMLDivElement>((_, ref) => {
   if (!('current' in ref)) {
     throw new Error('ref is not a RefObject');

--- a/src/ensuredForwardRef/ensuredForwardRef.test.tsx
+++ b/src/ensuredForwardRef/ensuredForwardRef.test.tsx
@@ -1,7 +1,9 @@
+import { jest } from '@jest/globals';
 import { render } from '@testing-library/react';
 import type { MutableRefObject } from 'react';
 import { ensuredForwardRef } from './ensuredForwardRef';
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 const TestComponent = ensuredForwardRef<HTMLDivElement>((_, ref) => {
   if (!('current' in ref)) {
     throw new Error('ref is not a RefObject');

--- a/src/ensuredForwardRef/ensuredForwardRef.tsx
+++ b/src/ensuredForwardRef/ensuredForwardRef.tsx
@@ -1,0 +1,49 @@
+import {
+  createRef,
+  forwardRef,
+  useMemo,
+  type ForwardRefExoticComponent,
+  type MutableRefObject,
+  type PropsWithoutRef,
+  type ReactElement,
+  type RefAttributes,
+} from 'react';
+
+export interface EnsuredForwardRefRenderFunction<T, P = Record<string | number | symbol, unknown>> {
+  (props: P, ref: MutableRefObject<T | null>): ReactElement | null;
+  displayName?: string | undefined;
+
+  // explicit rejected with `never` required due to
+  // https://github.com/microsoft/TypeScript/issues/36826
+  /**
+   * defaultProps are not supported on render functions
+   */
+  defaultProps?: never;
+  propTypes?: never;
+}
+
+export function ensuredForwardRef<T, P = Record<string | number | symbol, unknown>>(
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  Component: EnsuredForwardRefRenderFunction<T, P>,
+): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> {
+  return forwardRef<T, P>((props, ref) => {
+    const refObject = useMemo(() => {
+      if (ref !== null && 'current' in ref) {
+        return ref;
+      }
+
+      return new Proxy(createRef<T>(), {
+        set(target, prop, newValue): boolean {
+          if (prop !== 'current') {
+            return false;
+          }
+
+          ref?.(newValue);
+          return true;
+        },
+      });
+    }, [ref]);
+
+    return Component(props, refObject);
+  });
+}


### PR DESCRIPTION
Helper function to create ForwardRef component in which component function _always_ receive a
RefObject. New component function has the same function fignature as ForwardRef.

```tsx
const DemoComponent = ensuredForwardRef<HTMLDivElement>((_, ref) => {
  console.log(ref); // MutableRefObject<HTMLDivElement | null>

  return <div ref={ref} />;
});

...

const myRef = useRef<HTMLDivElement>();
const [myRef, setMyRef] = useState<HTMLDivElement | null>(null);

<DemoComponent />
<DemoComponent ref={myRef} />
<DemoComponent ref={setMyRef} />
```
