### PR TITLE
Properly memoize the initialTarget in useRefs

### DIFF
--- a/src/hooks/useRefs/useRefs.ts
+++ b/src/hooks/useRefs/useRefs.ts
@@ -6,7 +6,11 @@ import { createRef, useMemo, type RefObject } from 'react';
 export function useRefs<T extends Record<string | symbol, RefObject<unknown>>>(
   initialTarget?: Partial<T>,
 ): T {
-  const proxyTarget = useMemo(() => initialTarget ?? {}, [initialTarget]);
+  const proxyTarget = useMemo(
+    () => initialTarget ?? {},
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
 
   return useMemo(
     () =>


### PR DESCRIPTION
The memoized initialTarget in useRefs was thrown away when the reference was changed. This is not the expected behavior as the initial value should be created just once.

> It's not possible to create a test for this because the hook does not expose the initial reference through the proxy. The change was manually tested.