### PR TITLE
Make arrayRef stable between re-renders

### DIFF
--- a/src/utils/arrayRef/arrayRef.mdx
+++ b/src/utils/arrayRef/arrayRef.mdx
@@ -19,6 +19,8 @@ export function arrayRef<T extends MutableRefObject<Array<unknown> | null>>(
 
 Function that sets element on array index in given RefObject.
 
+The function is memoized and will not change between renders unless the ref or index changes.
+
 ## Usage
 
 Usage with `useRef` hook.

--- a/src/utils/arrayRef/arrayRef.test.ts
+++ b/src/utils/arrayRef/arrayRef.test.ts
@@ -31,4 +31,14 @@ describe('arrayRef', () => {
 
     expect(ref.current).toEqual([0]);
   });
+
+  it('should not create a new function when called multiple times', async () => {
+    const ref = createRef() as RefObject<Array<unknown>>;
+
+    // this might happen when re-rendering the parent component
+    const function1 = arrayRef(ref, 0);
+    const function2 = arrayRef(ref, 0);
+
+    expect(function1).toBe(function2);
+  });
 });


### PR DESCRIPTION
Previously, arrayRef always returned a new ref-function when being executed in a render. Components that receive this ref function might execute logic when this ref changes (e.g. the ensureForwardRef HoC). This could result in too much re-renders, or in some cases infinite recursive rendering where parents and children keep updating each other.

This change applies a memoize to the arrayRef implementation. It does this by generating a unique key for each ref/index combination (the function's parameters). Internally it uses a Map to allow mapping the ref objects to random strings, that can in turn be used as keys.