### PR TITLE
Check for undefined in ensuredForwardRef

### DIFF
--- a/src/hocs/ensuredForwardRef/ensuredForwardRef.test.tsx
+++ b/src/hocs/ensuredForwardRef/ensuredForwardRef.test.tsx
@@ -61,4 +61,20 @@ describe('ensuredForwardRef', () => {
 
     expect(_ref.current).toEqual(result.getByTestId('test'));
   });
+
+  it('should not break when passing undefined as a ref', () => {
+    let _ref: MutableRefObject<HTMLDivElement | null> = createRef();
+
+    const Component = ensuredForwardRef<HTMLDivElement>((_, ref) => {
+      _ref = ref;
+
+      return <div ref={ref} data-testid="test" />;
+    });
+
+    // Note; even though it passes undefined, it's still passed as `null`
+    // when the ensuredForwardRef is called. So this test doesn't do much.
+    const result = render(<Component ref={undefined} />);
+
+    expect(_ref.current).toEqual(result.getByTestId('test'));
+  });
 });

--- a/src/hocs/ensuredForwardRef/ensuredForwardRef.tsx
+++ b/src/hocs/ensuredForwardRef/ensuredForwardRef.tsx
@@ -29,7 +29,12 @@ export function ensuredForwardRef<T, P = Record<string | number | symbol, unknow
   // eslint-disable-next-line react/display-name
   return forwardRef<T, P>((props, ref) => {
     const refObject = useMemo(() => {
-      if (ref !== null && 'current' in ref) {
+      // At runtime, ref _could_ be undefined when this component is rendered
+      // from a framework level that doesn't leverage typescript.
+      // Example is Next.js with dynamic imports.
+      // This can't be covered with tests.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (ref !== null && ref !== undefined && 'current' in ref) {
         return ref;
       }
 


### PR DESCRIPTION
In some weird scenarios the ensuredForwardRef receives undefined as a ref, which we now check for.