### PR TITLE
Feature/new lifecycle hooks

### DIFF
--- a/src/hooks/useBeforeMount/useBeforeMount.stories.mdx
+++ b/src/hooks/useBeforeMount/useBeforeMount.stories.mdx
@@ -10,8 +10,8 @@ This is especially useful for initializing objects that are used in code further
 
 It's opposite of `useMount`, which runs asynchronously after the component is mounted.
 
-> If you only care about knowing if it is the first render, you can use the `useIsMounted`
-hook, which returns a boolean ref that you can use in other places, including JSX.
+> To know when a component is rendering for the first time, use the `useIsMounted` hook,
+which returned boolean ref can be used inline in other component code or JSX.
 
 ## Reference
 

--- a/src/hooks/useBeforeMount/useBeforeMount.stories.mdx
+++ b/src/hooks/useBeforeMount/useBeforeMount.stories.mdx
@@ -1,0 +1,40 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="hooks/lifecycle/useBeforeMount" />
+
+# useBeforeMount
+
+**Synchronously** run a function before the component is mounted, only once.
+
+This is especially useful for initializing objects that are used in code further down.
+
+It's opposite of `useMount`, which runs asynchronously after the component is mounted.
+
+> If you only care about knowing if it is the first render, you can use the `useIsMounted`
+hook, which returns a boolean ref that you can use in other places, including JSX.
+
+## Reference
+
+```ts
+function useBeforeMount(callback: () => void): void;
+```
+
+### Parameters
+
+* `callback` - A function to be executed during the initial render, before mounting, but not
+during subsequent renders.
+
+## Usage
+
+```tsx
+function DemoComponent() {
+  useBeforeMount(() => {
+    console.log('I will run before the component is mounted');
+  });
+
+  return (
+    <div>
+    </div>
+  );
+}
+```

--- a/src/hooks/useBeforeMount/useBeforeMount.test.tsx
+++ b/src/hooks/useBeforeMount/useBeforeMount.test.tsx
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
 import { renderHook } from '@testing-library/react';
+import { useEffect } from 'react';
 import { useBeforeMount } from './useBeforeMount.js';
 
 describe('useBeforeMount', () => {
@@ -16,6 +17,31 @@ describe('useBeforeMount', () => {
       useBeforeMount(spy);
     });
     expect(spy).toBeCalledTimes(1);
+  });
+
+  it('should execute during synchronous render, before mount', async () => {
+    const beforeMount = jest.fn();
+    const inlineSpy = jest.fn();
+    const mountedSpy = jest.fn();
+    renderHook(() => {
+      useEffect(() => {
+        mountedSpy();
+      }, []);
+
+      useBeforeMount(beforeMount);
+
+      inlineSpy();
+    });
+
+    expect(beforeMount).toBeCalledTimes(1);
+    expect(mountedSpy).toBeCalledTimes(1);
+    expect(inlineSpy).toBeCalledTimes(1);
+    expect(beforeMount.mock.invocationCallOrder[0]).toBeLessThan(
+      mountedSpy.mock.invocationCallOrder[0],
+    );
+    expect(beforeMount.mock.invocationCallOrder[0]).toBeLessThan(
+      inlineSpy.mock.invocationCallOrder[0],
+    );
   });
 
   it('should not execute a callback on re-renders', async () => {

--- a/src/hooks/useBeforeMount/useBeforeMount.test.tsx
+++ b/src/hooks/useBeforeMount/useBeforeMount.test.tsx
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 import { renderHook } from '@testing-library/react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { useMount } from '../useMount/useMount.js';
 import { useBeforeMount } from './useBeforeMount.js';
 
 describe('useBeforeMount', () => {
@@ -53,6 +54,25 @@ describe('useBeforeMount', () => {
 
     await Promise.resolve();
     rerender();
+    expect(spy).toBeCalledTimes(1);
+
+    await Promise.resolve();
+    rerender();
+    expect(spy).toBeCalledTimes(1);
+  });
+
+  it('should only execute once when setState is called during useMount', async () => {
+    const spy = jest.fn();
+    const { rerender } = renderHook(() => {
+      // eslint-disable-next-line react/hook-use-state
+      const [, setState] = useState(false);
+
+      useBeforeMount(spy);
+
+      useMount(() => {
+        setState(true);
+      });
+    });
     expect(spy).toBeCalledTimes(1);
 
     await Promise.resolve();

--- a/src/hooks/useBeforeMount/useBeforeMount.test.tsx
+++ b/src/hooks/useBeforeMount/useBeforeMount.test.tsx
@@ -1,0 +1,32 @@
+import { jest } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+import { useBeforeMount } from './useBeforeMount.js';
+
+describe('useBeforeMount', () => {
+  it('should not crash', async () => {
+    renderHook(() => {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      useBeforeMount(() => {});
+    });
+  });
+
+  it('should execute a callback on first render', async () => {
+    const spy = jest.fn();
+    renderHook(() => {
+      useBeforeMount(spy);
+    });
+    expect(spy).toBeCalledTimes(1);
+  });
+
+  it('should not execute a callback on re-renders', async () => {
+    const spy = jest.fn();
+    const { rerender } = renderHook(() => {
+      useBeforeMount(spy);
+    });
+    expect(spy).toBeCalledTimes(1);
+    rerender();
+    expect(spy).toBeCalledTimes(1);
+    rerender();
+    expect(spy).toBeCalledTimes(1);
+  });
+});

--- a/src/hooks/useBeforeMount/useBeforeMount.test.tsx
+++ b/src/hooks/useBeforeMount/useBeforeMount.test.tsx
@@ -50,8 +50,12 @@ describe('useBeforeMount', () => {
       useBeforeMount(spy);
     });
     expect(spy).toBeCalledTimes(1);
+
+    await Promise.resolve();
     rerender();
     expect(spy).toBeCalledTimes(1);
+
+    await Promise.resolve();
     rerender();
     expect(spy).toBeCalledTimes(1);
   });

--- a/src/hooks/useBeforeMount/useBeforeMount.ts
+++ b/src/hooks/useBeforeMount/useBeforeMount.ts
@@ -1,0 +1,18 @@
+import { useIsMounted } from '../useIsMounted/useIsMounted.js';
+
+/**
+ * Executes a callback during the initial render, before mounting, but not during subsequent
+ * renders.
+ *
+ * Opposed to `useEffect` / `useMount`, the callback is executed synchronously,
+ * before the component is mounted.
+ *
+ * @param callback A function to be executed during the initial render, before mounting, but not
+ * during subsequent renders.
+ */
+export function useBeforeMount(callback: () => void): void {
+  const isMounted = useIsMounted();
+  if (!isMounted.current) {
+    callback();
+  }
+}

--- a/src/hooks/useBeforeMount/useBeforeMount.ts
+++ b/src/hooks/useBeforeMount/useBeforeMount.ts
@@ -1,4 +1,5 @@
-import { useIsMounted } from '../useIsMounted/useIsMounted.js';
+import { useRef } from 'react';
+import { useMount } from '../useMount/useMount.js';
 
 /**
  * Executes a callback during the initial render, before mounting, but not during subsequent
@@ -11,8 +12,13 @@ import { useIsMounted } from '../useIsMounted/useIsMounted.js';
  * during subsequent renders.
  */
 export function useBeforeMount(callback: () => void): void {
-  const isMounted = useIsMounted();
-  if (!isMounted.current) {
+  const isBeforeMount = useRef(true);
+
+  if (isBeforeMount.current) {
     callback();
   }
+
+  useMount(() => {
+    isBeforeMount.current = false;
+  });
 }

--- a/src/hooks/useForceRerender/useForceRerender.stories.mdx
+++ b/src/hooks/useForceRerender/useForceRerender.stories.mdx
@@ -1,0 +1,43 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="hooks/lifecycle/useForceRerender" />
+
+# useForceRerender
+
+Forces a rerender of the component when the returned function is called.
+
+This should only be used when there is no other state that can be used to trigger a rerender.
+
+Examples could be to force a rerender after a timeout or interval, to compare the current time
+(that changes) with the time when the component was last updated.
+
+## Reference
+
+```ts
+function useForceRerender(): () => void;
+```
+
+### Returns
+
+* `forceRerender` - A function that can be called to force a rerender.
+
+## Usage
+
+```ts
+const forceRerender = useForceRerender();
+
+forceRerender();
+```
+
+```tsx
+function DemoComponent() {
+  const forceRerender = useForceRerender();
+
+  return (
+    <div>
+      <div>Time: {Date.now()}</div>
+      <button onClick={forceRerender}>Update</button>
+    </div>
+  );
+}
+```

--- a/src/hooks/useForceRerender/useForceRerender.stories.tsx
+++ b/src/hooks/useForceRerender/useForceRerender.stories.tsx
@@ -1,0 +1,35 @@
+/* eslint-disable react/jsx-no-literals,react/jsx-handler-names */
+import type { StoryObj } from '@storybook/react';
+import { useForceRerender } from './useForceRerender.js';
+
+export default {
+  title: 'hooks/lifecycle/useForceRerender',
+};
+
+function DemoComponent(): JSX.Element {
+  const forceRerender = useForceRerender();
+
+  return (
+    <div>
+      <div className="alert alert-primary">
+        <h4 className="alert-heading">Instructions!</h4>
+        <p className="mb-0">Click the &quot;Update&quot; button, and notice the date updating.</p>
+      </div>
+      <div className="card border-dark" data-ref="test-area">
+        <div className="card-header">Test Area</div>
+        <div className="card-body">
+          <p>{Date.now()}</p>
+          <button type="button" className="btn btn-primary" onClick={forceRerender}>
+            Update
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const Demo: StoryObj = {
+  render() {
+    return <DemoComponent />;
+  },
+};

--- a/src/hooks/useForceRerender/useForceRerender.test.tsx
+++ b/src/hooks/useForceRerender/useForceRerender.test.tsx
@@ -1,0 +1,39 @@
+import { jest } from '@jest/globals';
+import { act, renderHook } from '@testing-library/react';
+import { useForceRerender } from './useForceRerender.js';
+
+describe('useForceRerender', () => {
+  it('should not crash', async () => {
+    renderHook(() => useForceRerender());
+  });
+
+  it('should return a function', async () => {
+    const {
+      result: { current: forceRerender },
+    } = renderHook(() => useForceRerender());
+
+    expect(forceRerender).toBeInstanceOf(Function);
+  });
+
+  it('should force a rerender', async () => {
+    const spy = jest.fn();
+    const {
+      result: { current: forceRerender },
+    } = renderHook(() => {
+      // eslint-disable-next-line @typescript-eslint/no-shadow
+      const forceRerender = useForceRerender();
+
+      spy();
+
+      return forceRerender;
+    });
+
+    expect(spy).toBeCalledTimes(1);
+
+    await act(() => {
+      forceRerender();
+    });
+
+    expect(spy).toBeCalledTimes(2);
+  });
+});

--- a/src/hooks/useForceRerender/useForceRerender.ts
+++ b/src/hooks/useForceRerender/useForceRerender.ts
@@ -1,7 +1,7 @@
-// use an arbitrary large number instead of a toggle boolean to avoid potential optimization issues
-// when called multiple times in a single render, but have a cap to avoid overflow
 import { useReducer } from 'react';
 
+// use an arbitrary large number instead of a toggle boolean to avoid potential optimization issues
+// when called multiple times in a single render, but have a cap to avoid overflow
 const updateReducer = (value: number): number => (value + 1) % Number.MAX_SAFE_INTEGER;
 
 /**

--- a/src/hooks/useForceRerender/useForceRerender.ts
+++ b/src/hooks/useForceRerender/useForceRerender.ts
@@ -1,0 +1,21 @@
+// use an arbitrary large number instead of a toggle boolean to avoid potential optimization issues
+// when called multiple times in a single render, but have a cap to avoid overflow
+import { useReducer } from 'react';
+
+const updateReducer = (value: number): number => (value + 1) % Number.MAX_SAFE_INTEGER;
+
+/**
+ * Forces a rerender of the component when the returned function is called.
+ *
+ * This should only be used when there is no other state that can be used to trigger a rerender.
+ *
+ * Examples could be to force a rerender after a timeout or interval, to compare the current time
+ * (that changes) with the time when the component was last updated.
+ *
+ * @returns A function that can be called to force a rerender.
+ */
+export function useForceRerender(): () => void {
+  const [, update] = useReducer(updateReducer, 0);
+
+  return update;
+}

--- a/src/hooks/useIsMounted/useIsMounted.stories.mdx
+++ b/src/hooks/useIsMounted/useIsMounted.stories.mdx
@@ -19,7 +19,7 @@ often the same, this is not a problem.
 
 The initial `false` state before the component is mounted can be useful to conditionally execute
 some logic or render something. However, this hook will not cause a re-render, so it's best to use
-alternative hooks mentioned below in case you need that.
+alternative hooks mentioned below if that is required.
 
 The `false` state during and after the cleanup phase is useful for preventing memory leaks and
 preventing state updates after the component is unmounted. This is often the case when using
@@ -32,15 +32,15 @@ initial `useEffect` callbacks have been executed.
 If the component uses a setState directly from a `useMount`, the component will rerender during the
 mount phase, and the isMounted value will still be `false`.
 
-> If the code you want to execute before mount is more isolated as a side effect, you can use the
+> If code needs to be executed before mount and is more isolated as a side effect, use the
 `useBeforeMount` hook instead.
 
-> If your code result is different before and after mount, and should execute again, you can use the
+> If the code result is different before and after mount, and should execute again, use the
 `useIsMountedState` hook instead.
 
-> If you want to execute code after the component is **mounted**, you can use the `useMount` hook.
+> If code execution is required after the component is **mounted**, use the `useMount` hook.
 
-> If you want to execute code after the component is **unmounted**, you can use the `useUnmount`
+> If code execution is required after the component is **unmounted**, use the `useUnmount`
 hook.
 
 ## Reference

--- a/src/hooks/useIsMounted/useIsMounted.stories.mdx
+++ b/src/hooks/useIsMounted/useIsMounted.stories.mdx
@@ -1,0 +1,106 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="hooks/lifecycle/useIsMounted" />
+
+# useIsMounted
+
+Keeps track of whether the component is mounted, and returns a ref object that is updated
+accordingly.
+
+- `isMounted.current` is `false` before the component is mounted
+- `isMounted.current` is `true` after the component is mounted
+- `isMounted.current` is `false` during the unmount cleanup phase and after the component is
+  unmounted
+
+> Note that during the cleanup phase, the component is technically still mounted, even though the
+ref object is updated to `false`. This is because the cleanup phase is executed before the
+component is technically unmounted. However, since the logic during cleanup and after unmount is
+often the same, this is not a problem.
+
+The initial `false` state before the component is mounted can be useful to conditionally execute
+some logic or render something. However, this hook will not cause a re-render, so it's best to use
+alternative hooks mentioned below in case you need that.
+
+The `false` state during and after the cleanup phase is useful for preventing memory leaks and
+preventing state updates after the component is unmounted. This is often the case when using
+`useEffect` with an async function, and the async function is still running after the component
+is unmounted.
+
+> If the code you want to execute before mount is more isolated as a side effect, you can use the
+`useBeforeMount` hook instead.
+
+> If your code result is different before and after mount, and should execute again, you can use the
+`useIsMountedState` hook instead.
+
+> If you want to execute code after the component is **mounted**, you can use the `useMount` hook.
+
+> If you want to execute code after the component is **unmounted**, you can use the `useUnmount`
+hook.
+
+## Reference
+
+```ts
+function useIsMounted(): RefObject<boolean>;
+```
+
+### Returns
+
+* `RefObject<boolean>` - The current mounting state.
+  - `false` before the component is mounted
+  - `true` after the component is mounted
+  - `false` during the unmount cleanup phase and after the component is unmounted
+
+## Usage
+
+```ts
+const isMounted = useIsMounted();
+console.log(isMounted.current); // false
+```
+
+Use after unmount in async functions, to prevent memory leaks and state updates after unmount.
+
+```tsx
+function DemoComponent() {
+  const isMounted = useIsMounted();
+
+  useMount(() => {
+    fetchSomething().then(() => {
+      // check if the component is still mounted after the async operation
+      if (isMounted.current) {
+        // do something with the result
+      }
+    });
+  })
+
+  return (
+    <div>
+    </div>
+  );
+}
+```
+
+Use in `useEffect` cleanup, for some very specific scenarios.
+
+```tsx
+import { useEffect } from 'react';
+function DemoComponent() {
+  const isMounted = useIsMounted();
+
+  useEffect(() => {
+    // do something
+
+    return () => {
+      if (isMounted.current) {
+        // this is executed every time someChangingValue changes
+      } else {
+        // this is executed only once, when the component is unmounted
+      }
+    }
+  }, [someChangingValue]);
+
+  return (
+    <div>
+    </div>
+  );
+}
+```

--- a/src/hooks/useIsMounted/useIsMounted.stories.mdx
+++ b/src/hooks/useIsMounted/useIsMounted.stories.mdx
@@ -88,8 +88,7 @@ function DemoComponent() {
 Use in `useEffect` cleanup, for some very specific scenarios.
 
 ```tsx
-import { useEffect } from 'react';
-function DemoComponent() {
+function DemoComponent({ someChangingValue }) {
   const isMounted = useIsMounted();
 
   useEffect(() => {

--- a/src/hooks/useIsMounted/useIsMounted.stories.mdx
+++ b/src/hooks/useIsMounted/useIsMounted.stories.mdx
@@ -26,6 +26,12 @@ preventing state updates after the component is unmounted. This is often the cas
 `useEffect` with an async function, and the async function is still running after the component
 is unmounted.
 
+The state is set to `true` using a `queueMicrotask` callback, so it will be updated after all the
+initial `useEffect` callbacks have been executed.
+
+If the component uses a setState directly from a `useMount`, the component will rerender during the
+mount phase, and the isMounted value will still be `false`.
+
 > If the code you want to execute before mount is more isolated as a side effect, you can use the
 `useBeforeMount` hook instead.
 

--- a/src/hooks/useIsMounted/useIsMounted.stories.tsx
+++ b/src/hooks/useIsMounted/useIsMounted.stories.tsx
@@ -1,0 +1,58 @@
+/* eslint-disable react/jsx-no-literals,react/jsx-handler-names,no-console */
+import type { StoryObj } from '@storybook/react';
+import { useEffect } from 'react';
+import { useForceRerender } from '../useForceRerender/useForceRerender.js';
+import { useIsMountedState } from '../useIsMountedState/useIsMountedState.js';
+import { useIsMounted } from './useIsMounted.js';
+
+export default {
+  title: 'hooks/lifecycle/useIsMounted',
+};
+
+function DemoComponent(): JSX.Element {
+  const forceRerender = useForceRerender();
+  const isMountedState = useIsMountedState();
+  const isMounted = useIsMounted();
+
+  console.log('[render]', isMounted.current);
+
+  useEffect(() => {
+    console.log('[useEffect] isMounted.current', isMounted.current);
+  });
+
+  useEffect(() => {
+    console.log('[useEffect] isMountedState', isMountedState);
+  }, [isMountedState]);
+
+  return (
+    <div>
+      <div className="alert alert-primary">
+        <h4 className="alert-heading">Instructions!</h4>
+        <p className="mb-0">
+          Check the console for logged values. The first render, the values should be `true` for
+          all. The second render, it should be `false` for all.
+        </p>
+      </div>
+      <div>
+        Value:{' '}
+        <span className="badge rounded-pill bg-primary">
+          {isMounted.current ? 'true' : 'false'}
+        </span>
+      </div>
+      <div className="card border-dark" data-ref="test-area">
+        <div className="card-header">Test Area</div>
+        <div className="card-body">
+          <button type="button" className="btn btn-primary" onClick={forceRerender}>
+            Rerender
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const Demo: StoryObj = {
+  render() {
+    return <DemoComponent />;
+  },
+};

--- a/src/hooks/useIsMounted/useIsMounted.test.tsx
+++ b/src/hooks/useIsMounted/useIsMounted.test.tsx
@@ -1,0 +1,37 @@
+import { renderHook } from '@testing-library/react';
+import { useIsMounted } from './useIsMounted.js';
+
+describe('useIsMounted', () => {
+  it('should not crash', async () => {
+    renderHook(() => useIsMounted());
+  });
+
+  it('should return false on first render, before mounting', async () => {
+    const {
+      result: { current: isMounted },
+    } = renderHook(() => {
+      // eslint-disable-next-line @typescript-eslint/no-shadow
+      const isMounted = useIsMounted();
+
+      // special setup to capture this value _before_ the useEffect is executed and the ref is set
+      return isMounted.current;
+    });
+
+    expect(isMounted).toBe(false);
+  });
+
+  it('should return true on second render, after mounting', async () => {
+    const { result, rerender } = renderHook(() => useIsMounted());
+
+    rerender();
+    expect(result.current.current).toBe(true);
+  });
+
+  it('should return false on third render, after unmounting', async () => {
+    const { result, rerender, unmount } = renderHook(() => useIsMounted());
+
+    rerender();
+    unmount();
+    expect(result.current.current).toBe(false);
+  });
+});

--- a/src/hooks/useIsMounted/useIsMounted.ts
+++ b/src/hooks/useIsMounted/useIsMounted.ts
@@ -19,7 +19,7 @@ export function useIsMounted(): RefObject<boolean> {
     return () => {
       isMounted.current = false;
     };
-  });
+  }, []);
 
   return isMounted;
 }

--- a/src/hooks/useIsMounted/useIsMounted.ts
+++ b/src/hooks/useIsMounted/useIsMounted.ts
@@ -15,8 +15,23 @@ export function useIsMounted(): RefObject<boolean> {
   const isMounted = useRef(false);
 
   useEffect(() => {
-    isMounted.current = true;
+    let unmounted = false;
+
+    // Delay setting this to true until all other useEffects have run
+    // however, this can be too late if there are any "setState" actions inside
+    // the other useEffects that cause an immediate re-render in the same tick.
+    // This is okay, since multiple renders in the same tick can still be considered
+    // as the mounting phase, and very rare.
+    queueMicrotask(() => {
+      if (unmounted) {
+        return;
+      }
+
+      isMounted.current = true;
+    });
+
     return () => {
+      unmounted = true;
       isMounted.current = false;
     };
   }, []);

--- a/src/hooks/useIsMounted/useIsMounted.ts
+++ b/src/hooks/useIsMounted/useIsMounted.ts
@@ -1,0 +1,25 @@
+import { type RefObject, useEffect, useRef } from 'react';
+
+/**
+ * Keeps track of whether the component is mounted, and returns a ref object that is updated
+ * accordingly.
+ *
+ * - `isMounted.current` is `false` before the component is mounted
+ * - `isMounted.current` is `true` after the component is mounted
+ * - `isMounted.current` is `false` during the unmount cleanup phase and after the component is
+ *   unmounted
+ *
+ * @returns A boolean ref object that reflects whether the component is mounted.
+ */
+export function useIsMounted(): RefObject<boolean> {
+  const isMounted = useRef(false);
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  });
+
+  return isMounted;
+}

--- a/src/hooks/useIsMountedState/useIsMountedState.stories.mdx
+++ b/src/hooks/useIsMountedState/useIsMountedState.stories.mdx
@@ -44,7 +44,9 @@ console.log(isMounted); // false
 Trigger a re-render after the component is mounted to update the state.
 
 ```tsx
-function DemoComponent() {
+import {somethingSameAsServer, somethingCustomOnTheClient} from './somewhere.js';
+
+function DemoComponent({ otherItems }) {
   const isMounted = useIsMountedState();
 
   // help with SSR, since `isMounted` is part of the deps,

--- a/src/hooks/useIsMountedState/useIsMountedState.stories.mdx
+++ b/src/hooks/useIsMountedState/useIsMountedState.stories.mdx
@@ -13,8 +13,8 @@ This hook is useful when you want to perform an action after the component is mo
 when using SSR.
 There, the initial render is executed on the server, and subsequent renders are executed on the
 client. To prevent hydration errors, you want the first render on the client to be identical to
-the render on the server. If you have state that is only available on the client, you can use
-this hook to only render with the new state after the component is mounted.
+the render on the server. If there is state that is only available on the client, use
+this hook to only render with the new state after the component has mounted.
 
 The state is set to `true` using a `queueMicrotask` callback, so it will be updated after all the
 initial `useEffect` callbacks have been executed. Because of this delay, it will also make sure that

--- a/src/hooks/useIsMountedState/useIsMountedState.stories.mdx
+++ b/src/hooks/useIsMountedState/useIsMountedState.stories.mdx
@@ -1,0 +1,63 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="hooks/lifecycle/useIsMountedState" />
+
+# useIsMountedState
+
+Exposes the mounted state that is updated after the component is mounted.
+
+This hook uses `setState` to update the state after the component is mounted, which means that
+the component will be re-rendered after the first render.
+
+This hook is useful when you want to perform an action after the component is mounted, often used
+when using SSR.
+There, the initial render is executed on the server, and subsequent renders are executed on the
+client. To prevent hydration errors, you want the first render on the client to be identical to
+the render on the server. If you have state that is only available on the client, you can use
+this hook to only render with the new state after the component is mounted.
+
+
+## Reference
+
+```ts
+function useIsMountedState(): boolean;
+```
+### Returns
+
+* `boolean` - The mounted state, `false` initially, and `true` after the component is mounted.
+
+## Usage
+
+```ts
+const isMounted = useIsMountedState();
+console.log(isMounted); // false
+```
+
+```tsx
+```
+
+Trigger a re-render after the component is mounted to update the state.
+
+```tsx
+function DemoComponent() {
+  const isMounted = useIsMountedState();
+
+  // help with SSR, since `isMounted` is part of the deps,
+  // it will execute this `useMemo` again after the component is mounted
+  // but now with state that is only known on the client
+  const items = useMemo(() => {
+    if (!isMounted) {
+      return somethingSameAsServer(otherItems);
+    }
+    return somethingCustomOnTheClient(otherItems);
+  }, [otherItems, isMounted]);
+
+  return (
+    <div>
+      {items.map(item => <div>{item}</div>)}
+      {/* this element is not rendered on the server, so had to be delayed on the client */}
+      {isMounted && <div>Rendered only the client after mount</div>}
+    </div>
+  );
+}
+```

--- a/src/hooks/useIsMountedState/useIsMountedState.stories.mdx
+++ b/src/hooks/useIsMountedState/useIsMountedState.stories.mdx
@@ -16,6 +16,11 @@ client. To prevent hydration errors, you want the first render on the client to 
 the render on the server. If you have state that is only available on the client, you can use
 this hook to only render with the new state after the component is mounted.
 
+The state is set to `true` using a `queueMicrotask` callback, so it will be updated after all the
+initial `useEffect` callbacks have been executed. Because of this delay, it will also make sure that
+the component will re-render after the initial render, instead of during the mount phase, making it
+compatible with `useIsMounted`.
+
 
 ## Reference
 

--- a/src/hooks/useIsMountedState/useIsMountedState.stories.tsx
+++ b/src/hooks/useIsMountedState/useIsMountedState.stories.tsx
@@ -1,0 +1,49 @@
+/* eslint-disable react/jsx-no-literals,react/jsx-handler-names,no-console */
+import type { StoryObj } from '@storybook/react';
+import { useEffect } from 'react';
+import { useForceRerender } from '../useForceRerender/useForceRerender.js';
+import { useIsMountedState } from './useIsMountedState.js';
+
+export default {
+  title: 'hooks/lifecycle/useIsMountedState',
+};
+
+function DemoComponent(): JSX.Element {
+  const forceRerender = useForceRerender();
+  const isMounted = useIsMountedState();
+
+  console.log(`[render] ${isMounted}`);
+
+  useEffect(() => {
+    console.log(`[useEffect] isMounted ${isMounted}`);
+  });
+
+  return (
+    <div>
+      <div className="alert alert-primary">
+        <h4 className="alert-heading">Instructions!</h4>
+        <p className="mb-0">
+          Check the console for logged values. The first render, the values should be `false` for
+          both. The second render, it should be `true` for both.
+        </p>
+      </div>
+      <div>
+        Value: <span className="badge rounded-pill bg-primary">{isMounted ? 'true' : 'false'}</span>
+      </div>
+      <div className="card border-dark" data-ref="test-area">
+        <div className="card-header">Test Area</div>
+        <div className="card-body">
+          <button type="button" className="btn btn-primary" onClick={forceRerender}>
+            Rerender
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const Demo: StoryObj = {
+  render() {
+    return <DemoComponent />;
+  },
+};

--- a/src/hooks/useIsMountedState/useIsMountedState.test.tsx
+++ b/src/hooks/useIsMountedState/useIsMountedState.test.tsx
@@ -1,26 +1,31 @@
 import { jest } from '@jest/globals';
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { useIsMountedState } from './useIsMountedState.js';
 
 describe('useIsMountedState', () => {
   it('should not crash', async () => {
-    renderHook(() => useIsMountedState());
+    await act(async () => {
+      renderHook(() => useIsMountedState());
+    });
   });
 
   it('should update after rendering', async () => {
     const spy = jest.fn();
+
     const {
       result: { current: isMounted },
-    } = renderHook(() => {
-      // eslint-disable-next-line @typescript-eslint/no-shadow
-      const isMounted = useIsMountedState();
+    } = await act(async () =>
+      renderHook(() => {
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        const isMounted = useIsMountedState();
 
-      // this hook automatically re-renders because the `useIsMountedState` hook uses `useEffect`
-      // to update its state, so we need to capture the value _before_ the useEffect is executed.
-      spy(isMounted);
+        // this hook automatically re-renders because the `useIsMountedState` hook uses `useEffect`
+        // to update its state, so we need to capture the value _before_ the useEffect is executed.
+        spy(isMounted);
 
-      return isMounted;
-    });
+        return isMounted;
+      }),
+    );
 
     expect(isMounted).toBe(true);
     expect(spy).toBeCalledTimes(2);

--- a/src/hooks/useIsMountedState/useIsMountedState.test.tsx
+++ b/src/hooks/useIsMountedState/useIsMountedState.test.tsx
@@ -1,0 +1,30 @@
+import { jest } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+import { useIsMountedState } from './useIsMountedState.js';
+
+describe('useIsMountedState', () => {
+  it('should not crash', async () => {
+    renderHook(() => useIsMountedState());
+  });
+
+  it('should update after rendering', async () => {
+    const spy = jest.fn();
+    const {
+      result: { current: isMounted },
+    } = renderHook(() => {
+      // eslint-disable-next-line @typescript-eslint/no-shadow
+      const isMounted = useIsMountedState();
+
+      // this hook automatically re-renders because the `useIsMountedState` hook uses `useEffect`
+      // to update its state, so we need to capture the value _before_ the useEffect is executed.
+      spy(isMounted);
+
+      return isMounted;
+    });
+
+    expect(isMounted).toBe(true);
+    expect(spy).toBeCalledTimes(2);
+    expect(spy).toHaveBeenNthCalledWith(1, false);
+    expect(spy).toHaveBeenNthCalledWith(2, true);
+  });
+});

--- a/src/hooks/useIsMountedState/useIsMountedState.ts
+++ b/src/hooks/useIsMountedState/useIsMountedState.ts
@@ -13,7 +13,11 @@ export function useIsMountedState(): boolean {
   const [isMounted, setIsMounted] = useState(false);
 
   useMount(() => {
-    setIsMounted(true);
+    // make sure that mounting has finished
+    // and then trigger a render in the next "tick"
+    queueMicrotask(() => {
+      setIsMounted(true);
+    });
   });
 
   return isMounted;

--- a/src/hooks/useIsMountedState/useIsMountedState.ts
+++ b/src/hooks/useIsMountedState/useIsMountedState.ts
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import { useMount } from '../useMount/useMount.js';
+
+/**
+ * Exposes the mounted state that is updated after the component is mounted.
+ *
+ * This hook uses setState to update the state after the component is mounted, which means that
+ * the component will be re-rendered after the first render.
+ *
+ * @returns A boolean indicating whether the component is mounted.
+ */
+export function useIsMountedState(): boolean {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useMount(() => {
+    setIsMounted(true);
+  });
+
+  return isMounted;
+}

--- a/src/hooks/useMount/useMount.mdx
+++ b/src/hooks/useMount/useMount.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="hooks/useMount" />
+<Meta title="hooks/lifecycle/useMount" />
 
 # useMount
 

--- a/src/hooks/useRefValue/useRefValue.stories.mdx
+++ b/src/hooks/useRefValue/useRefValue.stories.mdx
@@ -1,0 +1,43 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="hooks/useRefValue" />
+
+# useRefValue
+
+Keeps a ref up to date with a changing value.
+
+Normal values are captured in scopes, while refs are not. This means that if you want to use a
+changing value in a callback, you need to use a ref.
+
+## Reference
+
+```ts
+function useRefValue<T>(value: T): RefObject<T>;
+```
+
+### Parameters
+
+* `value` – The value to keep in the ref.
+
+### Returns
+
+* `RefObject` - A ref object that is updated with the value.
+
+## Usage
+
+```tsx
+function DemoComponent({ foo }) {
+  const ref = useRefValue(foo);
+
+  const onClick = useCallback(() => {
+    // always contains the latest value of foo
+    console.log(ref.current);
+  });
+
+  return (
+    <div onClick={onClick}>
+      Click me
+    </div>
+  );
+}
+```

--- a/src/hooks/useRefValue/useRefValue.test.tsx
+++ b/src/hooks/useRefValue/useRefValue.test.tsx
@@ -1,0 +1,24 @@
+import { renderHook } from '@testing-library/react';
+import { useRefValue } from './useRefValue.js';
+
+describe('useRefValue', () => {
+  it('should not crash', async () => {
+    renderHook(() => useRefValue(1));
+  });
+
+  it('should have the correct initial value', async () => {
+    const { result } = renderHook(() => useRefValue(1));
+
+    expect(result.current.current).toBe(1);
+  });
+
+  it('should update the value', async () => {
+    const { result, rerender } = renderHook((value) => useRefValue(value), {
+      initialProps: 1,
+    });
+
+    expect(result.current.current).toBe(1);
+    rerender(2);
+    expect(result.current.current).toBe(2);
+  });
+});

--- a/src/hooks/useRefValue/useRefValue.ts
+++ b/src/hooks/useRefValue/useRefValue.ts
@@ -1,0 +1,17 @@
+import { type RefObject, useRef } from 'react';
+
+/**
+ * Keeps a ref up to date with a changing value.
+ *
+ * Normal values are captured in scopes, while refs are not. This means that if you want to use a
+ * changing value in a callback, you need to use a ref.
+ *
+ * @param value The value to keep in the ref.
+ * @returns A ref object that is updated with the value.
+ */
+export function useRefValue<T>(value: T): RefObject<T> {
+  const ref = useRef(value);
+  ref.current = value;
+
+  return ref;
+}

--- a/src/hooks/useRefValue/useRefValue.ts
+++ b/src/hooks/useRefValue/useRefValue.ts
@@ -3,8 +3,8 @@ import { type RefObject, useRef } from 'react';
 /**
  * Keeps a ref up to date with a changing value.
  *
- * Normal values are captured in scopes, while refs are not. This means that if you want to use a
- * changing value in a callback, you need to use a ref.
+ * Normal values are captured in scopes, while refs are not. Therefore a changing value in a callback 
+ * requires the use of a ref.
  *
  * @param value The value to keep in the ref.
  * @returns A ref object that is updated with the value.

--- a/src/hooks/useUnmount/useUnmount.mdx
+++ b/src/hooks/useUnmount/useUnmount.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="hooks/useUnmount" />
+<Meta title="hooks/lifecycle/useUnmount" />
 
 # useUnmount
 

--- a/src/hooks/useUnmount/useUnmount.test.tsx
+++ b/src/hooks/useUnmount/useUnmount.test.tsx
@@ -13,17 +13,24 @@ describe('useUnmount', () => {
   });
 
   it('should not run on re-renders', async () => {
-    const spy = jest.fn();
+    const spy1 = jest.fn();
+    const spy2 = jest.fn();
     const { rerender, unmount } = renderHook(useUnmount, {
-      initialProps: () => spy(),
+      initialProps: () => spy1(),
     });
 
-    expect(spy).toBeCalledTimes(0);
-    rerender();
-    expect(spy).toBeCalledTimes(0);
-    rerender();
-    expect(spy).toBeCalledTimes(0);
+    expect(spy1).toBeCalledTimes(0);
+
+    rerender(() => spy2());
+    expect(spy1).toBeCalledTimes(0);
+    expect(spy2).toBeCalledTimes(0);
+
+    rerender(() => spy2());
+    expect(spy1).toBeCalledTimes(0);
+    expect(spy2).toBeCalledTimes(0);
+
     unmount();
-    expect(spy).toBeCalledTimes(1);
+    expect(spy1).toBeCalledTimes(0);
+    expect(spy2).toBeCalledTimes(1);
   });
 });

--- a/src/hooks/useUnmount/useUnmount.ts
+++ b/src/hooks/useUnmount/useUnmount.ts
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
+import { useRefValue } from '../useRefValue/useRefValue.js';
 
 /**
  * React lifecycle hook that calls a function after the component is unmounted.
@@ -12,14 +13,12 @@ import { useEffect, useRef } from 'react';
  * ```
  */
 export function useUnmount(callbackFunction: () => void): void {
-  const callbackRef = useRef<(() => void) | undefined>(callbackFunction);
-  // update the ref each render so if it change the newest callback will be invoked
-  callbackRef.current = callbackFunction;
+  const callbackRef = useRefValue(callbackFunction);
 
   useEffect(
     () => () => {
       callbackRef.current?.();
     },
-    [],
+    [callbackRef],
   );
 }

--- a/src/hooks/useUnmount/useUnmount.ts
+++ b/src/hooks/useUnmount/useUnmount.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 /**
  * React lifecycle hook that calls a function after the component is unmounted.
@@ -12,9 +12,14 @@ import { useEffect } from 'react';
  * ```
  */
 export function useUnmount(callbackFunction: () => void): void {
+  const callbackRef = useRef<(() => void) | undefined>(callbackFunction);
+  // update the ref each render so if it change the newest callback will be invoked
+  callbackRef.current = callbackFunction;
+
   useEffect(
-    () => callbackFunction,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    () => () => {
+      callbackRef.current?.();
+    },
     [],
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 /* PLOP_ADD_EXPORT */
+export * from './hooks/useRefValue/useRefValue.js';
 export * from './components/AutoFill/AutoFill.js';
 export * from './hocs/ensuredForwardRef/ensuredForwardRef.js';
 export * from './hooks/useBeforeMount/useBeforeMount.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,13 @@
 /* PLOP_ADD_EXPORT */
 export * from './components/AutoFill/AutoFill.js';
 export * from './hocs/ensuredForwardRef/ensuredForwardRef.js';
+export * from './hooks/useBeforeMount/useBeforeMount.js';
 export * from './hooks/useDocumentEventListener/useDocumentEventListener.js';
 export * from './hooks/useEventListener/useEventListener.js';
+export * from './hooks/useForceRerender/useForceRerender.js';
 export * from './hooks/useHasFocus/useHasFocus.js';
+export * from './hooks/useIsMountedState/useIsMountedState.js';
+export * from './hooks/useIsMounted/useIsMounted.js';
 export * from './hooks/useIsomorphicLayoutEffect/useIsomorphicLayoutEffect.js';
 export * from './hooks/useMediaQuery/useMediaQuery.js';
 export * from './hooks/useMount/useMount.js';


### PR DESCRIPTION
Move all lifecycle hooks into their own storybook folder, so it's easier to compare which are available, and to see which to use when.

- added `useBeforeMount`, to execute synchronous code only before mount
- added `useIsMounted`, a ref to keep track of the mounted state
- added `useIsMountedState`, to force a re-render after mount
- added `useForceRerender`, to force a re-render on demand