### PR TITLE
Add debounce to useResizeObserver hook

### DIFF
--- a/src/hooks/useResizeObserver/useResizeObserver.stories.mdx
+++ b/src/hooks/useResizeObserver/useResizeObserver.stories.mdx
@@ -7,7 +7,7 @@ import { Meta } from '@storybook/blocks';
 This hook allows you to add a ResizeObserver for an element and remove it when the component
 unmounts.
 
-By default the callback is debouncedat 200ms to improve performance.
+By default the callback is debounced at 200ms to improve performance.
 
 ## Reference
 

--- a/src/hooks/useResizeObserver/useResizeObserver.stories.mdx
+++ b/src/hooks/useResizeObserver/useResizeObserver.stories.mdx
@@ -15,7 +15,7 @@ By default the callback is debounced at 200ms to improve performance.
 function useResizeObserver(
   ref: RefObject<Element>,
   callback: ResizeObserverCallback,
-  debounceTime: number | null,
+  debounceTime?: number | null,
 ): void;
 ```
 

--- a/src/hooks/useResizeObserver/useResizeObserver.stories.mdx
+++ b/src/hooks/useResizeObserver/useResizeObserver.stories.mdx
@@ -7,10 +7,16 @@ import { Meta } from '@storybook/blocks';
 This hook allows you to add a ResizeObserver for an element and remove it when the component
 unmounts.
 
+By default the callback is debouncedat 200ms to improve performance.
+
 ## Reference
 
 ```ts
-function useResizeObserver(ref: RefObject<Element>, callback: ResizeObserverCallback): void;
+function useResizeObserver(
+  ref: RefObject<Element>,
+  callback: ResizeObserverCallback,
+  debounceTime: number | null,
+): void;
 ```
 
 ## Usage

--- a/src/hooks/useResizeObserver/useResizeObserver.ts
+++ b/src/hooks/useResizeObserver/useResizeObserver.ts
@@ -37,10 +37,8 @@ export function useResizeObserver(
     resizeObserverInstance.observe(element);
 
     return () => {
-      if (resizeObserverInstance && element) {
-        resizeObserverInstance.unobserve(element);
-        resizeObserverInstanceCallbacks.delete(element);
-      }
+      resizeObserverInstance?.unobserve(element);
+      resizeObserverInstanceCallbacks.delete(element);
     };
   }, [ref, callback, debounceTime]);
 }

--- a/src/hooks/useResizeObserver/useResizeObserver.ts
+++ b/src/hooks/useResizeObserver/useResizeObserver.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import { debounce } from 'lodash-es';
 import { type RefObject, useEffect } from 'react';
 

--- a/src/hooks/useResizeObserver/useResizeObserver.ts
+++ b/src/hooks/useResizeObserver/useResizeObserver.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+import { debounce } from 'lodash-es';
 import { type RefObject, useEffect } from 'react';
 
 /**
@@ -6,19 +8,26 @@ import { type RefObject, useEffect } from 'react';
  *
  * @param ref - The ref to observe
  * @param callback - The callback to fire when the element resizes
+ * @param debounceTime - The number in milliseconds the callback is debounced
  */
-export function useResizeObserver(ref: RefObject<Element>, callback: ResizeObserverCallback): void {
+export function useResizeObserver(
+  ref: RefObject<Element>,
+  callback: ResizeObserverCallback,
+  debounceTime?: number | null,
+): void {
   useEffect(() => {
-    const resizeObserverInstance = new ResizeObserver(callback);
-
     if (ref.current === null) {
       throw new Error('`ref.current` is undefined');
     }
 
-    resizeObserverInstance.observe(ref.current);
+    const element = ref.current;
+    const callbackFunction =
+      debounceTime === null ? callback : debounce(callback, debounceTime ?? 200);
+    const resizeObserverInstance = new ResizeObserver(callbackFunction);
+    resizeObserverInstance.observe(element);
 
     return () => {
-      resizeObserverInstance.disconnect();
+      resizeObserverInstance.unobserve(element);
     };
-  }, [ref, callback]);
+  }, [ref, callback, debounceTime]);
 }


### PR DESCRIPTION
From a performance perspective we should debounce this hook. 
A third parameter is added so the develop can pass the debounced time or ignored at all by adding null. Default debounce time is set at 200ms.