### PR TITLE
Use unreffable for ResizeObserver target

### DIFF
--- a/src/hooks/useResizeObserver/useResizeObserver.mdx
+++ b/src/hooks/useResizeObserver/useResizeObserver.mdx
@@ -4,19 +4,24 @@ import { Meta } from '@storybook/blocks';
 
 # useResizeObserver
 
-This hook allows you to add a ResizeObserver for an element and remove it when the component
-unmounts.
+The `useResizeObserver` hook is used to observe the size of an HTML element and call a callback
+function when the size changes. It uses the `ResizeObserver` API to observe the element, the target
+is disconnected when the component unmounts.
 
 ## Reference
 
 ```ts
-function useResizeObserver(ref: RefObject<Element>, callback: ResizeObserverCallback): void;
+function useResizeObserver(ref: Unreffable<Element | null>, callback: ResizeObserverCallback): void;
 ```
 
-## Usage
+## Using `useResizeObserver` with a RefObject
+
+In this example, the `useRef` hook is used to create a `RefObject` for the `div` element which is
+initially set to null. The `useResizeObserver` hook is then called with the ref variable and a
+callback function that logs a message to the console when the `div` element is resized.
 
 ```tsx
-function DemoComponent() {
+function MyComponent() {
   const ref = useRef<HTMLDivElement>(null);
 
   useResizeObserver(ref, () => {
@@ -24,5 +29,23 @@ function DemoComponent() {
   });
 
   return <div ref={ref}></div>;
+}
+```
+
+## Using `useResizeObserver` with an element
+
+In this example, the `useState` hook is used to create a state variable element which is initially
+set to null. The `useResizeObserver` hook is then called with the element variable and a callback
+function that logs a message to the console when the `div` element is resized.
+
+```tsx
+function MyComponent() {
+  const [element, setElement] = useState<HTMLDivElement | null>(null);
+
+  useResizeObserver(element, () => {
+    console.log('Element resized');
+  });
+
+  return <div ref={setElement}></div>;
 }
 ```

--- a/src/hooks/useResizeObserver/useResizeObserver.stories.tsx
+++ b/src/hooks/useResizeObserver/useResizeObserver.stories.tsx
@@ -1,5 +1,5 @@
 import type { StoryObj } from '@storybook/react';
-import { type ReactElement, useRef } from 'react';
+import { type ReactElement, useRef, useState } from 'react';
 import { useResizeObserver } from './useResizeObserver.js';
 
 export default {
@@ -7,14 +7,25 @@ export default {
 };
 
 function DemoComponent(): ReactElement {
-  const ref = useRef<HTMLDivElement>(null);
+  const elementRef = useRef<HTMLDivElement>(null);
+  const [element, setElement] = useState<HTMLDivElement | null>(null);
 
-  useResizeObserver(ref, () => {
+  useResizeObserver(elementRef, () => {
     // eslint-disable-next-line no-console
-    console.log('Element resized');
+    console.log('Element from RefObject resized');
   });
 
-  return <div ref={ref}></div>;
+  useResizeObserver(element, () => {
+    // eslint-disable-next-line no-console
+    console.log('Element from state resized');
+  });
+
+  return (
+    <>
+      <div ref={elementRef}></div>
+      <div ref={setElement}></div>
+    </>
+  );
 }
 
 export const Demo: StoryObj = {

--- a/src/hooks/useResizeObserver/useResizeObserver.ts
+++ b/src/hooks/useResizeObserver/useResizeObserver.ts
@@ -1,24 +1,29 @@
-import { type RefObject, useEffect } from 'react';
+import { useEffect } from 'react';
+import { unref, type Unreffable } from '../../utils/unref/unref.js';
 
 /**
  * This hook allows you to add a ResizeObserver for an element and remove it
  * when the component unmounts.
  *
- * @param ref - The ref to observe
+ * @param target - The target to observe
  * @param callback - The callback to fire when the element resizes
  */
-export function useResizeObserver(ref: RefObject<Element>, callback: ResizeObserverCallback): void {
+export function useResizeObserver(
+  target: Unreffable<Element | null>,
+  callback: ResizeObserverCallback,
+): void {
   useEffect(() => {
-    const resizeObserverInstance = new ResizeObserver(callback);
+    const element = unref(target);
 
-    if (ref.current === null) {
-      throw new Error('`ref.current` is undefined');
+    if (element === null) {
+      return;
     }
 
-    resizeObserverInstance.observe(ref.current);
+    const resizeObserverInstance = new ResizeObserver(callback);
+    resizeObserverInstance.observe(element);
 
     return () => {
       resizeObserverInstance.disconnect();
     };
-  }, [ref, callback]);
+  }, [target, callback]);
 }


### PR DESCRIPTION
`Unreffable` allows us to use `RefObjects` and regular variables in a hook, this makes the `useResizeObserver` hook more versatile.