### PR TITLE
Bugfix/fix newlines in plop templates

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 dist
 public
 test-results
+plop-templates

--- a/plop-templates/hook/{{camelCase hookName}}.mdx.hbs
+++ b/plop-templates/hook/{{camelCase hookName}}.mdx.hbs
@@ -2,13 +2,30 @@ import { Meta } from '@storybook/blocks';
 
 <Meta title='hooks/{{camelCase hookName}}' />
 
-#
-{{camelCase hookName}}
+# {{camelCase hookName}}
 
-Please add a description about the `{{camelCase hookName}}` hook. ## Reference ```ts function
-{{camelCase hookName}}(): void ``` ### Parameters * `TODO` - Describe the parameters here. ###
-Returns * `TODO` - Define the return value here. ## Usage ```tsx function DemoComponent() {
-{{camelCase hookName}}(); return (
-<div>
-</div>
-); } ```
+Please add a description about the `{{camelCase hookName}}` hook.
+
+## Reference
+
+```ts
+function {{camelCase hookName}}(): void
+```
+
+### Parameters
+
+* `TODO` - Describe the parameters here.
+
+### Returns
+
+* `TODO` - Define the return value here.
+
+## Usage
+```tsx
+function DemoComponent() {
+  {{camelCase hookName}}();
+  return (
+    <div></div>
+  );
+}
+```

--- a/plop-templates/hook/{{camelCase hookName}}.stories.tsx.hbs
+++ b/plop-templates/hook/{{camelCase hookName}}.stories.tsx.hbs
@@ -1,24 +1,35 @@
-import type { StoryObj } from '@storybook/react'; import type { ReactElement } from 'react'; import
-{
-{{camelCase hookName}}
-} from './{{camelCase hookName}}.js'; export default { title: 'hooks/{{camelCase hookName}}', };
+import type { StoryObj } from '@storybook/react';
+import type { ReactElement } from 'react';
+import { {{camelCase hookName}} } from './{{camelCase hookName}}.js';
+
+export default {
+  title: 'hooks/{{camelCase hookName}}',
+};
+
 function DemoComponent(): ReactElement {
-{{camelCase hookName}}(); return (
-<div>
-  <div className='alert alert-primary'>
-    <h4 className='alert-heading'>Instructions!</h4>
-    <p className='mb-0'>Add instructions about the hook here.</p>
-  </div>
-  <div>
-    Value:
-    <span className='badge rounded-pill bg-primary'>{/* value */}</span>
-  </div>
-  <div className='card border-dark' data-ref='test-area'>
-    <div className='card-header'>Test Area</div>
-    <div className='card-body'>
-      <p>TODO: Implement a test case for the hook.</p>
+  {{camelCase hookName}}();
+
+  return (
+    <div>
+      <div className='alert alert-primary'>
+        <h4 className='alert-heading'>Instructions!</h4>
+        <p className='mb-0'>Add instructions about the hook here.</p>
+      </div>
+      <div>
+        Value: <span className='badge rounded-pill bg-primary'>{/* value */}</span>
+      </div>
+      <div className='card border-dark' data-ref='test-area'>
+        <div className='card-header'>Test Area</div>
+        <div className='card-body'>
+          <p>TODO: Implement a test case for the hook.</p>
+        </div>
+      </div>
     </div>
-  </div>
-</div>
-); } export const Demo: StoryObj = { render() { return
-<DemoComponent />; } };
+  );
+}
+
+export const Demo: StoryObj = {
+  render() {
+    return <DemoComponent />;
+  }
+};

--- a/plop-templates/hook/{{camelCase hookName}}.test.tsx.hbs
+++ b/plop-templates/hook/{{camelCase hookName}}.test.tsx.hbs
@@ -1,5 +1,10 @@
-import { renderHook } from '@testing-library/react'; import {
-{{camelCase hookName}}
-} from './{{camelCase hookName}}.js'; describe('{{camelCase hookName}}', () => { it('should not
-crash', async () => { renderHook(() => { return
-{{camelCase hookName}}(); }); }); });
+import { renderHook } from '@testing-library/react';
+import { {{camelCase hookName}} } from './{{camelCase hookName}}.js';
+
+describe('{{camelCase hookName}}', () => {
+  it('should not crash', async () => {
+    renderHook(() => {
+      return {{camelCase hookName}}();
+    });
+  });
+});

--- a/plop-templates/hook/{{camelCase hookName}}.test.tsx.hbs
+++ b/plop-templates/hook/{{camelCase hookName}}.test.tsx.hbs
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react';
+import { describe, it } from 'vitest';
 import { {{camelCase hookName}} } from './{{camelCase hookName}}.js';
 
 describe('{{camelCase hookName}}', () => {

--- a/plop-templates/hook/{{camelCase hookName}}.ts.hbs
+++ b/plop-templates/hook/{{camelCase hookName}}.ts.hbs
@@ -1,3 +1,11 @@
-/** * TODO: Add a complete description about your hook * * This description should include at least
-the following: * - Describe the arguments * - Describe the return value */ export function
-{{camelCase hookName}}(): void { // TODO: Implement the hook here }
+/**
+ * TODO: Add a complete description about your hook
+ *
+ * This description should include at least the following:
+ * - Describe the arguments
+ * - Describe the return value
+*/
+
+export function {{camelCase hookName}}(): void {
+  // TODO: Implement the hook here
+}

--- a/src/hooks/useRefs/useRefs.mdx
+++ b/src/hooks/useRefs/useRefs.mdx
@@ -29,7 +29,7 @@ type DemoComponentRefs = Refs<{
 }>;
 
 function DemoComponent() {
-  const refs = useRef<DemoComponentRefs>();
+  const refs = useRefs<DemoComponentRefs>();
 
   console.log(refs.heading.current); // HTMLHeadingElement | null
   console.log(refs.buttons.current); // Array<HTMLButtonElement | null> | null


### PR DESCRIPTION
Prevents plop templates from being changed by prettier (when run by lint-staged), which would mess up the newlines.

- reformatted the templates
- added a missing import to a template
- fixed a typo in an unrelated hook doc